### PR TITLE
docs: improve benchmark package init

### DIFF
--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -7,4 +7,5 @@ working with AutoPT benchmark definition files.
 from .loader import find_benchmark_by_name, load_benchmarks
 from .models import BenchmarkItem
 
+
 __all__ = ["BenchmarkItem", "find_benchmark_by_name", "load_benchmarks"]

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,4 +1,8 @@
-"""Benchmark loading and benchmark models."""
+"""Benchmark loading and benchmark models.
+
+Exposes loader utilities and the BenchmarkItem data model for
+working with AutoPT benchmark definition files.
+"""
 
 from .loader import find_benchmark_by_name, load_benchmarks
 from .models import BenchmarkItem


### PR DESCRIPTION
Expand docstring and fix formatting in benchmark __init__.py.